### PR TITLE
Make device selection stick in Audio Interface Configuration

### DIFF
--- a/AudMeS.cpp
+++ b/AudMeS.cpp
@@ -453,6 +453,8 @@ void MainFrame::set_custom_props() {
   SetIcon(wxICON(audmes));
 #endif
 
+  m_PlayDev = 0;
+  m_RecordDev = 0;
   m_SamplingFreq = 44100;
 
   choice_osc_l_res->SetSelection(15);
@@ -1081,16 +1083,22 @@ void MainFrame::OnSelectSndCard(wxCommandEvent& WXUNUSED(event)) {
   RWAudioDevList playDevList;
   RWAudioDevList recordDevList;
   unsigned long int newFrequency = m_SamplingFreq;
+  AIStreamSettings m_StreamSettings;
 
   m_RWAudio->GetRWAudioDevices(&playDevList, &recordDevList);
 
   AudioInterfaceDialog dlg(this);
 
-  dlg.SetDevices(recordDevList, playDevList, m_SamplingFreq);
+  m_StreamSettings.playDev = m_PlayDev;
+  m_StreamSettings.recordDev = m_RecordDev;
+  m_StreamSettings.freq = m_SamplingFreq;
+  dlg.SetDevices(recordDevList, playDevList, m_StreamSettings);
   if (wxID_OK == dlg.ShowModal()) {
     // send settings to RWAudio
     dlg.GetSelectedDevs(&recdev, &pldev, &newFrequency);
     m_RWAudio->SetSndDevices(recdev, pldev, newFrequency);
+	m_PlayDev = pldev;
+	m_RecordDev = recdev;
     m_SamplingFreq = newFrequency;
     window_1_spe->SetFsample(m_SamplingFreq);
     window_1_frm->SetFsample(m_SamplingFreq);

--- a/AudMeS.h
+++ b/AudMeS.h
@@ -170,6 +170,8 @@ class MainFrame : public wxFrame {
   unsigned long int m_OscBufferLength;
   unsigned long int m_SpeBufferLength;
 
+  unsigned int m_PlayDev;
+  unsigned int m_RecordDev;
   unsigned long int m_SamplingFreq;
 };
 

--- a/RWAudio_IO.cpp
+++ b/RWAudio_IO.cpp
@@ -383,6 +383,7 @@ int RWAudio::GetRWAudioDevices(RWAudioDevList *play, RWAudioDevList *record) {
     if (info.probed == true) {
       //      std::cout << "device = " << i << "; name: " << info.name << "\n";
 
+
       // add play card
       if ((info.outputChannels > 0) || (info.duplexChannels > 0)) {
         play->card_info.push_back(info);

--- a/RWAudio_IO.h
+++ b/RWAudio_IO.h
@@ -28,7 +28,7 @@
 
 struct RWAudioDevList {
   std::vector<RtAudio::DeviceInfo> card_info;
-  std::vector<int> card_pos;
+  std::vector<unsigned int> card_pos;
 };
 
 class RWAudio {

--- a/dlg_audiointerface.cpp
+++ b/dlg_audiointerface.cpp
@@ -198,12 +198,12 @@ wxIcon AudioInterfaceDialog::GetIconResource(const wxString& name) {
 }
 
 void AudioInterfaceDialog::SetDevices(RWAudioDevList devreclist, RWAudioDevList devpllist,
-                                      unsigned long int freq) {
+                                      AIStreamSettings streamSettings ) {
   unsigned int pldev = 0, recdev = 0;
   unsigned int cfreq = 0;
   m_DevRecList = devreclist;
   m_DevPlayList = devpllist;
-  m_freq = freq;
+  m_freq = streamSettings.freq;
 
   wxChoice* p_cho = (wxChoice*)FindWindow(ID_OUTDEV_CHO);
   if (!p_cho) {
@@ -211,11 +211,15 @@ void AudioInterfaceDialog::SetDevices(RWAudioDevList devreclist, RWAudioDevList 
   }
   p_cho->Clear();
 
+  int curSelection = 0;
   for (unsigned int i = 0; i < devpllist.card_info.size(); i++) {
     wxString newstr(devpllist.card_info[i].name.c_str(), wxConvUTF8);
     p_cho->Append(newstr);
+    if (devpllist.card_pos[i] == streamSettings.playDev) {
+      curSelection = i;
+    }
   }
-  p_cho->SetSelection(0);
+  p_cho->SetSelection(curSelection);
 
   p_cho = (wxChoice*)FindWindow(ID_INDEV_CHO);
   if (!p_cho) {
@@ -223,11 +227,15 @@ void AudioInterfaceDialog::SetDevices(RWAudioDevList devreclist, RWAudioDevList 
   }
   p_cho->Clear();
 
+  curSelection = 0;
   for (unsigned int i = 0; i < devreclist.card_info.size(); i++) {
     wxString newstr(devreclist.card_info[i].name.c_str(), wxConvUTF8);
     p_cho->Append(newstr);
+    if (devreclist.card_pos[i] == streamSettings.recordDev) {
+      curSelection = i;
+    }
   }
-  p_cho->SetSelection(0);
+  p_cho->SetSelection(curSelection);
 
   p_cho = (wxChoice*)FindWindow(ID_FREQ_CHO);
   if (!p_cho) {

--- a/dlg_audiointerface.h
+++ b/dlg_audiointerface.h
@@ -74,12 +74,20 @@
  * AudioInterfaceDialog class declaration
  */
 
+struct AIStreamSettings {
+	unsigned int playDev;
+	unsigned int recordDev;
+	unsigned long int freq;
+};
+
+
 class AudioInterfaceDialog : public wxDialog {
   DECLARE_DYNAMIC_CLASS(AudioInterfaceDialog)
   DECLARE_EVENT_TABLE()
 
   RWAudioDevList m_DevRecList;
   RWAudioDevList m_DevPlayList;
+  AIStreamSettings m_StreamSettings;
   unsigned long int m_freq;
 
  public:
@@ -122,7 +130,7 @@ class AudioInterfaceDialog : public wxDialog {
 
   ////@begin AudioInterfaceDialog member variables
   ////@end AudioInterfaceDialog member variables
-  void SetDevices(RWAudioDevList devreclist, RWAudioDevList devpllist, unsigned long int freq);
+  void SetDevices(RWAudioDevList devreclist, RWAudioDevList devpllist, AIStreamSettings streamSettings);
   void GetSelectedDevs(unsigned int* recdev, unsigned int* playdev, unsigned long int* newfreq);
   void OnChoiceChanged(wxCommandEvent& event);
 };


### PR DESCRIPTION
Hello Walter,

Whenever I tried to change the audio interface settings, the dialog always showed the first available devices, regardless of what had been selected. That is confusing, but it also meant that when for example a new output device was selected, the input device would also be set again to the first device in the list. Without knowing or warning.

I thought it would be better if the setting of the selected device would be retained during execution of the program, and the correct devices being shown when the dialog was opened again.

I have made some changes so that the settings are stored in fields of of the MainFrame class. Just like the sample frequency is stored. And these settings are passed to the dialog before it is set up. It seemed to me that the sample frequency and selected devices were sufficiently similar to be handled in the same way.

Your action to get and enumerate all audio devices again before opening the dialog is correct I think. Audio devices are some kind of dynamic configuration on a running computer and should be re-iterated every time.

As you see I store the device _number_ which is selected. In hindsight it might have been better to store the device name. When a device is unplugged and replace by something else, the device number will be the same again but the name different. Which will suddenly show the name of a different device in the list as selected device. Actually I don't know what is the preferred behavior.

I hope you can agree with these changes. Or let me know if you want me to improve the way this is handled.

Kind regards
Johannes
